### PR TITLE
Safari service image height bug

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -6,7 +6,7 @@
   box-shadow: 0 2px $highlight-color;
   padding: 0 1em;
   margin: 0;
-  position: fixed; // Remove this to make header scrollable again
+  position: absolute; // Make fixed once we implement the Intersection Observer
   top: 0;
   left: 0;
   right: 0;

--- a/css/main.scss
+++ b/css/main.scss
@@ -759,6 +759,7 @@ a.btn-card {
 
 .page-content img {
   width: auto;
+  max-height: 125px;
 }
 
 .shared_header_icon {


### PR DESCRIPTION
- Fix insanely tall service images (Safari)
- Make mobile nav scroll to avoid some of the janky behavior with the drop-down menu

## Before
<img width="672" alt="Screen Shot 2020-01-17 at 3 14 28 PM" src="https://user-images.githubusercontent.com/2592907/72650203-00f3fe00-393d-11ea-8551-92ff818fea22.png">

## After
<img width="672" alt="Screen Shot 2020-01-17 at 3 14 41 PM" src="https://user-images.githubusercontent.com/2592907/72650295-5203f200-393d-11ea-857b-4558bf147891.png">
