### PR TITLE
Fix too-tall Services page images, without effecting ALL images

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -850,6 +850,10 @@ text-decoration: none;
       border-bottom: 1px solid #e4e4e4;
     }
 
+    .service-img {
+      max-height: 125px;
+    }
+
     @media (min-width: $medium){
       flex-flow: row nowrap;
       .service-border{


### PR DESCRIPTION
Last change to `.page-content img` messed up a lot of other images. 

Using a reasonably targeted selector of `.service-img` to adjust only service page images. 