### PR TITLE
Use featimg when sharing posts on any Social

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -44,7 +44,7 @@
   <meta property="og:site_name" content="{{ site.title }}" />
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="{% if page.cover %}{{ page.cover | prepend: site.baseurl | prepend: site.url }}{% else %}{{ site.protocols.fb_image | prepend: site.baseurl | prepend: site.url }}{% endif %}" />
+  <meta property="og:image" content="{% if page.layout == 'post' and page.featimg %}{{ page.featimg | prepend: site.baseurl | prepend: site.url }}{% elsif page.cover %}{{ page.cover | prepend: site.baseurl | prepend: site.url }}{% else %}{{ site.protocols.fb_image | prepend: site.baseurl | prepend: site.url }}{% endif %}" />
   <meta property="og:image:type" content="{{ site.protocols.fb_image_type }}" />
   <meta property="og:image:width" content="{{ site.protocols.fb_image_width }}" />
   <meta property="og:image:height" content="{{ site.protocols.fb_image_height }}" />


### PR DESCRIPTION
Closes #49 

> the image is incorrect on Linkedin vs. Twitter

Not sure how to validate this locally but, based on the symptom described, I think this could fix it. 

## Before
<img width="1193" alt="Screen Shot 2020-02-21 at 10 57 18 PM" src="https://user-images.githubusercontent.com/2592907/75087536-db8b7e80-54fe-11ea-9b73-73fc14c6e6d3.png">

## After
<img width="1160" alt="Screen Shot 2020-02-21 at 10 57 01 PM" src="https://user-images.githubusercontent.com/2592907/75087537-e6461380-54fe-11ea-8e30-6909eb5e062d.png">
