### PR TITLE
update post layout to include a by line

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,9 +9,9 @@ layout: default
         <header class="post-header">
           <h1 class="title blog-post">{{ page.title }}</h1>
           <div class="post-date">
-            {{ page.date | date: "%B %-d, %Y" }}
+            {% if page.author.size > 0 %} Written by {{ page.author }} {% endif %}
           </div>
-          {% include social_links_header.html %}
+          {{ page.date | date: "%B %-d, %Y" }} {% include social_links_header.html %}
         </header>
       </div>
     </div>


### PR DESCRIPTION
Closes #61 

Will include a _"written by"_ line under the header, populated by adding an `author` field to the front matter of a post. 

<img width="1414" alt="Screen Shot 2020-03-11 at 11 04 14 PM" src="https://user-images.githubusercontent.com/34528865/76483271-f3af3900-63ec-11ea-981b-bed709db0a36.png">
