### PR TITLE
added shorter titles for blog page

### DIFF
--- a/_includes/article_index.html
+++ b/_includes/article_index.html
@@ -17,7 +17,9 @@
 
         {% endif %}
         <a href="{{ post.url | prepend: goraft/ | replace: '//', '/'}}">
-            <h3>{{ post.title | truncate: 27 }}</h3>
+            {% if post.short_title.size > 0 %}<h3>{{ post.short_title | truncate: 27 }}</h3>
+            {% else %} <h3>{{ post.title | truncate: 27 }}</h3>
+            {% endif %}
             <span class="date">{{ post.date | date: '%B %d, %Y' }}</span>
         </a>
           <p class="post-content">{{ post.content | strip_html | truncate: 165 }}</p>


### PR DESCRIPTION
Closes #56 

Enables the option to have shorter text on blog page, populated by adding a `shorter_title` field to the front matter of a post. If not present will use the full post title. In both cases with truncate to 27 chars. 

<img width="1162" alt="Screen Shot 2020-03-11 at 11 15 16 PM" src="https://user-images.githubusercontent.com/34528865/76483748-3a516300-63ee-11ea-8155-bf0be1673270.png">
