### PR TITLE
Make blog post headers consistently purple

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -176,6 +176,9 @@ pre code.hljs {
 	*	Posts
 	*/
 	.post {
+		h1, h2, h3, h4, h5, h6 {
+			color: #17097c;
+		}
 		ul {
 			margin-bottom: 1em;
 		}


### PR DESCRIPTION
# Before
![Screen Shot 2020-04-14 at 1 33 23 PM](https://user-images.githubusercontent.com/2592907/79267525-8d3b9180-7e56-11ea-9d65-7e8c02c99c2a.png)


# After
![Screen Shot 2020-04-14 at 1 33 34 PM](https://user-images.githubusercontent.com/2592907/79267534-8f9deb80-7e56-11ea-9255-4effba0ed561.png)
