### PR TITLE
css mobile improvements

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -147,6 +147,23 @@ section .section-title {
 }
 
 @media (min-width: $large) {
+  li.nav-link a, li.nav-link a:hover  {
+    text-shadow: 0 3px 3px rgba(0, 0, 0, 0.9) !important;
+  }
+
+  li.nav-link a:hover::after{
+    content:'';
+    position:absolute;
+    bottom:-3px;
+    left:0px;
+    width:100%;
+    height:5px;
+    background:rgba(0, 0, 0, 0.9);
+    box-shadow:0 0 3px rgba(0, 0, 0, 0.9);
+  }
+}
+
+@media (min-width: $large) {
 
   #introducing {
     flex-flow: row;
@@ -243,9 +260,19 @@ section .section-title {
 .hero-header {
   display: table-cell;
   vertical-align: middle;
-
   &.title {
     padding-top: 40px;
+  }
+}
+
+@media (max-width: $small){
+  .site-header-container.has-cover .title,
+  .post-header-container.has-cover .title {
+    font-size: 1em;
+  }
+
+  .site-header-container .scrim, .post-header-container .scrim {
+    padding: 1em 1em;
   }
 }
 
@@ -298,6 +325,10 @@ section .section-title {
     height: auto;
     background-size: cover;
   }
+}
+
+.site-header-container.has-cover, .post-header-container.has-cover {
+  text-shadow: 0 3px 3px rgba(0, 0, 0, 0.9) !important;
 }
 
 .page {
@@ -648,12 +679,27 @@ $speed: 300ms;
 	overflow: hidden;
 	border-radius: 0;
 	z-index: 1;
+  display: block;
+  height: 175px;
+  width: auto;
+  margin: 0 auto;
+}
+
+@media (max-width: $large){
+  .card-featimg {
+    height: 100px;
+    width: auto;
+  }
 }
 
 .card-featimg img {
-	width: auto;
 	display: block;
   height: 175px;
+  @media (max-width: $large){
+    height: 100px;
+  }
+  width: auto;
+
   margin: 0 auto;
 }
 
@@ -673,10 +719,10 @@ $speed: 300ms;
     transform: translate(-50%,-50%);
 }
 .card-featimg span h4{
-        font-size: 12px;
-        margin:0;
-        padding:10px 5px;
-         line-height: 0;
+  font-size: 12px;
+  margin:0;
+  padding:10px 5px;
+  line-height: 0;
 }
 .card-desc {
 	padding: 1.25rem;
@@ -685,17 +731,17 @@ $speed: 300ms;
 
 .card-desc h3 {
 	color: #000000;
-    font-weight: 600;
-    font-size: 1.25em;
-    line-height: 1.3em;
-    margin-top: 0;
-    margin-bottom: 5px;
-    padding: 0;
+  font-weight: 600;
+  font-size: 1.25em;
+  line-height: 1.3em;
+  margin-top: 0;
+  margin-bottom: 5px;
+  padding: 0;
 }
 
 .card-desc p {
 	color: #747373;
-    font-size: 14px;
+  font-size: 14px;
 	font-weight: 400;
 	font-size: 1em;
 	line-height: 1.5;
@@ -704,6 +750,36 @@ $speed: 300ms;
 	padding: 0;
 	font-family: 'Raleway', sans-serif;
 }
+
+@media (max-width: $large){
+  .card-desc {
+  	padding: 1rem;
+    margin: 5px;
+  }
+
+  .card-desc h3 {
+  	color: #000000;
+    font-weight: 600;
+    font-size: 1em;
+    line-height: 1.2em;
+    margin-top: 0;
+    margin-bottom: 5px;
+    padding: 0;
+  }
+
+  .card-desc p {
+  	color: #747373;
+    font-size: 14px;
+  	font-weight: 400;
+  	font-size: 0.9em;
+  	line-height: 1.25;
+  	margin: 0px;
+  	margin-bottom: 10px;
+  	padding: 0;
+  	font-family: 'Raleway', sans-serif;
+  }
+}
+
 .btn-card{
 	background-color: #1ABC9C;
 	color: #fff;
@@ -750,14 +826,11 @@ a.btn-card {
   margin: 0 auto;
   padding: 30px 0;
   flex: 1;
-}
 
+  @media (max-width: $medium){
+    padding: 0;
+  }
 
-.card-featimg {
-  width: auto;
-  display: block;
-  height: 175px;
-  margin: 0 auto;
 }
 /* End card section */
 
@@ -789,6 +862,12 @@ a.btn-card {
 .post-date {
   font-size: 20px;
   padding-bottom: 10px;
+}
+
+@media(max-width: $medium) {
+  .post-date {
+    font-size: 14px;
+  }
 }
 
 #services .cards .card {
@@ -975,7 +1054,7 @@ text-decoration: none;
     margin-bottom: 20px;
 
     @include media($large){
-      float: right; 
+      float: right;
       padding: 10px;
       height: 400px;
       margin-bottom: auto;


### PR DESCRIPTION
Closes #107 

Improvements to navbar visibility with light background 

Current: 
![Screen Shot 2020-04-28 at 4 15 44 PM](https://user-images.githubusercontent.com/34528865/80533397-88ed9900-896b-11ea-9eb6-ef613e419632.png)

New: 
<img width="784" alt="Screen Shot 2020-04-28 at 4 16 30 PM" src="https://user-images.githubusercontent.com/34528865/80533456-a884c180-896b-11ea-805a-80d0feccaab5.png">

Lower title and hero size on blog post pages + white space savings where possible on smaller screens. 

Current: 
![Screen Shot 2020-04-28 at 4 18 24 PM](https://user-images.githubusercontent.com/34528865/80533612-e84ba900-896b-11ea-820a-1bc13fcce622.png)
![Screen Shot 2020-04-28 at 3 55 22 PM](https://user-images.githubusercontent.com/34528865/80533699-0b765880-896c-11ea-8653-a10a797cb90c.png)


New:
<img width="354" alt="Screen Shot 2020-04-28 at 3 55 03 PM" src="https://user-images.githubusercontent.com/34528865/80533674-02858700-896c-11ea-839c-6db4dec8b118.png">
<img width="348" alt="Screen Shot 2020-04-28 at 3 54 56 PM" src="https://user-images.githubusercontent.com/34528865/80533712-10d3a300-896c-11ea-81ae-fd8ae0e50842.png">

